### PR TITLE
Add owns_data_ flag to FabBlock in e/a-m-t, fix missing wrap argument

### DIFF
--- a/examples/amr-merge-tree/include/fab-block.h
+++ b/examples/amr-merge-tree/include/fab-block.h
@@ -20,14 +20,16 @@ struct FabBlock
     {
     }
 
-    FabBlock(T* data, const Shape& shape) :
-            fab(data, shape, /* c_order = */ false)
+    FabBlock(T* data, const Shape& shape, bool owns_data=false) :
+            fab(data, shape, /* c_order = */ false),
+            owns_data_(owns_data)
     {
     }
 
-    FabBlock(T* data, const std::vector<std::string>& extra_names, const std::vector<T*>& extra_data, const Shape& shape) :
+    FabBlock(T* data, const std::vector<std::string>& extra_names, const std::vector<T*>& extra_data, const Shape& shape, bool owns_data=false) :
             fab(data, shape, /* c_order = */ false),
-            extra_names_(extra_names)
+            extra_names_(extra_names),
+            owns_data_(owns_data)
     {
         for(T* extra_ptr : extra_data)
         {
@@ -37,6 +39,9 @@ struct FabBlock
 
     ~FabBlock()
     {
+        if (!owns_data_)
+            return;
+
         for (auto& fab : extra_fabs_)
             delete[] fab.data();
 
@@ -66,6 +71,7 @@ struct FabBlock
     std::vector<std::string> extra_names_; // vector of names additional components
     std::vector<diy::GridRef<T, D>> extra_fabs_; // vector of additional components' data
 
+    bool owns_data_ { false };
 };
 
 template<class T, unsigned D>

--- a/examples/amr-merge-tree/src/amr-merge-tree.cpp
+++ b/examples/amr-merge-tree/src/amr-merge-tree.cpp
@@ -137,7 +137,10 @@ void read_from_file(std::string infn,
 
     if (ends_with(infn, ".npy"))
     {
-        read_from_npy_file<DIM>(infn, world, nblocks, master_reader, assigner, header, domain);
+        diy::RegularDecomposer<diy::DiscreteBounds>::BoolVector wrap;
+        for(int i = 0; i < DIM; ++i)
+            wrap.push_back(true);
+        read_from_npy_file<DIM>(infn, world, nblocks, master_reader, assigner, header, domain, wrap);
     } else
     {
         if (split)

--- a/examples/amr-merge-tree/src/amr-plot-reader.cpp
+++ b/examples/amr-merge-tree/src/amr-plot-reader.cpp
@@ -363,7 +363,7 @@ void read_amr_plotfile(std::string infile,
         {
             auto* l = static_cast<diy::AMRLink*>(cp.link());
             auto receivers = link_unique(l, cp.gid());
-            fmt::print("{}: level = {}, shape = {}, core = {} - {}, bounds = {} - {}, neighbors = {}\n", cp.gid(), l->level(), b->fab.shape(), l->core().min, l->core().max, l->bounds().min, l->bounds().max, container_to_string(receivers));
+            fmt::print("{}: level = {}, shape = {}, core = {} - {}, bounds = {} - {}\n", cp.gid(), l->level(), b->fab.shape(), l->core().min, l->core().max, l->bounds().min, l->bounds().max);
         });
     }
 }


### PR DESCRIPTION
I got two compilation errors that I have not seen before. One is because I assume that diy::BlockID is printable (I simply removed printing this debug message). Probably, adding << operator to diy::BlockID is useful. The other one is trivial, missing wrap argument.