### PR TITLE
Updating for C++20

### DIFF
--- a/include/reeber/triplet-merge-tree.h
+++ b/include/reeber/triplet-merge-tree.h
@@ -112,8 +112,8 @@ class TripletMergeTree
 
         friend struct ::reeber::Serialization<TripletMergeTree>;
 
-        Neighbor    new_node()                          { Neighbor p = alloc_.allocate(1); alloc_.construct(p); return p; }
-        void        delete_node(Neighbor p)             { alloc_.destroy(p); alloc_.deallocate(p,1); }
+        Neighbor new_node() { Neighbor p = alloc_.allocate(1); std::allocator_traits<decltype(alloc_)>::construct(alloc_, p); return p; }
+        void delete_node(Neighbor p) { std::allocator_traits<decltype(alloc_)>::destroy(alloc_, p); alloc_.deallocate(p, 1); }    
 
         // return total number of vertices in all nodes
         size_t      n_vertices_total() const;


### PR DESCRIPTION
Context: AMReX has been updated to C++20.
This PR updates two lines of code to conform with C++20. Without this change the following error appears.
```
triplet-merge-tree.h(116): error: class 
"std::allocator<reeber::TripletMergeTreeNode<reeber::AmrVertexId, Real>>" has no member "destroy"
```
